### PR TITLE
WEB-16793-remove-scrutinizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,4 @@
 /.travis.yml        export-ignore
 /docs               export-ignore
 /phpunit.xml        export-ignore
-/.scrutinizer.yml   export-ignore
 /tests              export-ignore

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Latest Version](https://img.shields.io/packagist/v/mariano/disque-php.svg?style=flat-square)](https://github.com/mariano/disque-php/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/mariano/disque-php/master.svg?style=flat-square)](https://travis-ci.org/mariano/disque-php)
-[![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/mariano/disque-php.svg?style=flat-square)](https://scrutinizer-ci.com/g/mariano/disque-php/code-structure)
-[![Quality Score](https://img.shields.io/scrutinizer/g/mariano/disque-php.svg?style=flat-square)](https://scrutinizer-ci.com/g/mariano/disque-php)
 [![Total Downloads](https://img.shields.io/packagist/dt/mariano/disque-php.svg?style=flat-square)](https://packagist.org/packages/mariano/disque-php)
 
 A PHP library for the very promising [disque](https://github.com/antirez/disque)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6",
-        "scrutinizer/ocular": "~1.1",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Scrutinizer badges from the README.
  * Updated export settings to include the `.scrutinizer.yml` file in archive exports.
  * Removed the "scrutinizer/ocular" development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->